### PR TITLE
Update Constant.php

### DIFF
--- a/src/Constant.php
+++ b/src/Constant.php
@@ -43,7 +43,7 @@ class Constant
         }
 
         $this->dayOfWeeks = [];
-        $dayOfWeeks = ["អាទិត្យ", "ច័ន្ទ", "អង្គារ", "ពុធ", "ព្រហស្បតិ៍", "សុក្រ", "សៅរ៍"];
+        $dayOfWeeks = ["អាទិត្យ", "ចន្ទ", "អង្គារ", "ពុធ", "ព្រហស្បតិ៍", "សុក្រ", "សៅរ៍"];
         foreach ($dayOfWeeks as $key => $day) {
             $this->dayOfWeeks[$day] = $key;
         }


### PR DESCRIPTION
- change from "ច័ន្ទ" to "ចន្ទ"
-  Ref: ក្រុមប្រឹក្សា​ជាតិ​ភាសា​ខ្មែរ បានសម្រេច​ជា​ឯកច្ឆន្ទ ឲ្យ​ប្រើពាក្យ ថ្ងៃ​ចន្ទ ដែល​ពុំមាន​សំយោគសញ្ញា​នៅ​ពីលើ  ដើម្បី​ប្រកបដោយ​ភាពងាយស្រួល​។