### PR TITLE
Update README with mb_trim error resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ You can install the package via composer:
 composer require asorasoft/chhankitek
 ```
 
+If faced error: Call to undefined function Asorasoft\Chhankitek\Traits\mb_trim(), then try to following commands:
+```bash
+composer require symfony/polyfill-mbstring
+composer dump-autoload
+php artisan optimize:clear
+```
+
 ## Usage
 
 ```php


### PR DESCRIPTION
The Chhankitek package uses `mb_trim()`, which is only available in PHP 8.4+.

Although the package documentation states support for PHP 8.2+/Laravel 10+, running it on PHP 8.2 causes the following error:

`Call to undefined function Asorasoft\Chhankitek\Traits\mb_trim()`

This update resolves the issue by installing `symfony/polyfill-mbstring`, which provides compatibility for missing multibyte string functions in older PHP versions.